### PR TITLE
Adding test for common language effect size & rank-biserial correlation

### DIFF
--- a/R/wmwTest.R
+++ b/R/wmwTest.R
@@ -115,7 +115,7 @@ wmwTest.default <- function(matrix,
                             indexList,
                             valType=c("p.greater", "p.less", "p.two.sided", "U",
                                 "abs.log10p.greater","log10p.less","abs.log10p.two.sided",
-                                "Q"),
+                                "Q", "r", "f"),
                             simplify=TRUE) {
     if(!is.matrix(matrix) || !is(indexList, "IndexList"))
         stop("'matrix' and 'indexList' must be matrix and an IndexList object, respectively")

--- a/R/wmwTest.R
+++ b/R/wmwTest.R
@@ -96,8 +96,8 @@ TYPE_CODES <- c("p.greater"=0L, "p.less"=1L,
                 "log10p.less"=5L,
                 "abs.log10p.two.sided"=6L,
                 "Q"=7L,
-		"r"=8L,
-		"f"=9L)
+                "r"=8L,
+                "f"=9L)
 #'prints the options of valTypes of wmwTest
 valTypes <- function() names(TYPE_CODES)
 

--- a/src/wmw_test.c
+++ b/src/wmw_test.c
@@ -44,9 +44,9 @@ double wmw_test_stat(double rankSum, int nInds, int nTotal, double tieCoef, Test
   if(type == U) {
     res = uStat;
   } else if (type == r) {
-    res = 2 * uStat / nTotal / nInds - 1;
+    res = 2 * uStat / nInds / (nTotal - nInds) - 1;
   } else if (type == f) {
-    res = uStat / nTotal / nInds;
+    res = uStat / nInds / (nTotal - nInds);
   } else {
     mu = (double)nInds*nBg*0.5; // NOT mu=n1*n2*0.5
     sigma2 = nInds*nBg*(nTotal+1.0)/12.0*tieCoef; //NOT sigma2 = n1*n2*(n+1)/12*tieCoef

--- a/src/wmw_test.c
+++ b/src/wmw_test.c
@@ -23,7 +23,7 @@ typedef enum testtype {greater=0,
                        abslog10twoSided=6,
                        Q=7,
                        r=8,
-		       f=9} TestType;
+                       f=9} TestType;
 
 /*
  * void pnorm_both(double x, double *cum, double *ccum, int i_tail, int log_p)

--- a/tests/testthat/test-normalzed.R
+++ b/tests/testthat/test-normalzed.R
@@ -1,0 +1,40 @@
+# test rank-biserial correlation and common language effect size
+library(BioQC)
+
+context("Test correspondance between U and rank-biserial correlation")
+n1 <- 300
+n2 <- 200
+rd <- c(rnorm(n1), rnorm(n2, -0.2))
+ind <- c(rep(FALSE, n1), rep(TRUE, n2))
+
+# one-dimensional vector
+wmw_U <- wmwTest(rd, ind, valType = "U")
+wmw_U_f <- wmw_U / n1 / n2
+wmw_U_r <- 2 * wmw_U / n1 / n2 - 1
+wmw_r <- wmwTest(rd, ind, valType = "r")
+wmw_f <- wmwTest(rd, ind, valType = "f")
+
+
+## matrix form
+rmat <- matrix(c(rd, rd + rnorm(length(rd)), rd + rnorm(length(rd))), ncol = 3, byrow = FALSE)
+
+wmw_mat_U <- wmwTest(rmat, ind, valType = "U")
+wmw_mat_U_f <- wmw_mat_U / n1 / n2
+wmw_mat_U_r <- 2 * wmw_mat_U / n1 / n2 - 1
+wmw_mat_r <- wmwTest(rmat, ind, valType = "r")
+wmw_mat_f <- wmwTest(rmat, ind, valType = "f")
+
+test_that("Common language effect size and rank-biserial correlation values are compatible", {
+  expect_equivalent(wmw_r, 2 * wmw_f - 1)
+  expect_equivalent(wmw_mat_r, 2 * wmw_mat_f - 1)
+})
+
+test_that("Common language effect size corresponds to U value", {
+  expect_equivalent(wmw_f, wmw_U_f)
+  expect_equivalent(wmw_mat_f, wmw_mat_U_f)
+})
+
+test_that("Rank-biserial correlation corresponds to U value", {
+  expect_equivalent(wmw_r, wmw_U_r)
+  expect_equivalent(wmw_mat_r, wmw_mat_U_r)
+})


### PR DESCRIPTION
Hi David,

As you suggested, adding some tests. Please find the summary below:
- adding tests for `valType`s `r` and `f`
- correctly divide U by `n1` and `n2` in the C code
- correct formatting (spaces/tabs)
- allow calling `wmwTest` with `valType = "r"` and `valType = "f"`